### PR TITLE
update to retrofit 2.0.0-beta3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,28 +19,10 @@ android {
                 "\"${ribotAppGoogleApiServerClientId}\"")
     }
 
-    signingConfigs {
-        // You must set up an environment var before release signing
-        // Run: export RIBOT_APP_KEY={password}
-        release {
-            storeFile file("${ribotAppKeystoreReleaseLocation}")
-            keyAlias "${ribotAppReleaseKeyAlias}"
-            storePassword "${ribotAppReleaseStorePassword}"
-            keyPassword "${ribotAppReleaseKeyPassword}"
-        }
-
-        debug {
-            storeFile file("${ribotAppKeystoreDebugLocation}")
-            keyAlias "${ribotAppDebugKeyAlias}"
-            storePassword "${ribotAppDebugStorePassword}"
-            keyPassword "${ribotAppDebugKeyPassword}"
-        }
-    }
 
     buildTypes {
 
         release {
-            signingConfig signingConfigs.release
 
             /*
             * By default ProGuard optimizations are disabled. If you want to enable them
@@ -83,8 +65,7 @@ play {
 dependencies {
     final PLAY_SERVICES_VERSION = '8.3.0'
     final SUPPORT_LIBRARY_VERSION = '23.1.1'
-    final RETROFIT_VERSION = '2.0.0-beta2'
-    final OKHTTP_VERSION = '2.7.0'
+    final RETROFIT_VERSION = '2.0.0-beta3'
     final DAGGER_VERSION = '2.0.2'
     final DEXMAKER_VERSION = '1.4'
     final HAMCREST_VERSION = '1.3'
@@ -102,11 +83,10 @@ dependencies {
     compile "com.android.support:percent:$SUPPORT_LIBRARY_VERSION"
     compile "com.android.support:design:$SUPPORT_LIBRARY_VERSION"
 
-    compile "com.squareup.retrofit:retrofit:$RETROFIT_VERSION"
-    compile "com.squareup.retrofit:converter-gson:$RETROFIT_VERSION"
-    compile "com.squareup.retrofit:adapter-rxjava:$RETROFIT_VERSION"
-    compile "com.squareup.okhttp:okhttp:$OKHTTP_VERSION"
-    compile "com.squareup.okhttp:logging-interceptor:$OKHTTP_VERSION"
+    compile "com.squareup.retrofit2:retrofit:$RETROFIT_VERSION"
+    compile "com.squareup.retrofit2:converter-gson:$RETROFIT_VERSION"
+    compile "com.squareup.retrofit2:adapter-rxjava:$RETROFIT_VERSION"
+    compile 'com.squareup.okhttp3:logging-interceptor:3.0.1'
 
     compile 'com.squareup.picasso:picasso:2.5.2'
     compile 'com.squareup.sqlbrite:sqlbrite:0.5.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,79 +1,98 @@
 apply plugin: 'com.android.application'
-apply from: '../config/quality/quality.gradle'
-apply plugin: 'com.github.triplet.play'
-apply plugin: 'com.neenbedankt.android-apt'
+    apply from: '../config/quality/quality.gradle'
+    apply plugin: 'com.github.triplet.play'
+    apply plugin: 'com.neenbedankt.android-apt'
 
-android {
+    android {
     compileSdkVersion 23
     buildToolsVersion '23.0.2'
 
     defaultConfig {
-        applicationId 'io.ribot.app'
-        minSdkVersion 19
-        targetSdkVersion 23
-        testInstrumentationRunner "${applicationId}.runner.RxAndroidJUnitRunner"
-        versionCode 5000
-        // Major -> Millions, Minor -> Thousands, Bugfix -> Hundreds. E.g 1.3.72 == 1,003,072
-        versionName '0.5.0'
-        buildConfigField("String", "GOOGLE_API_SERVER_CLIENT_ID",
-                "\"${ribotAppGoogleApiServerClientId}\"")
+    applicationId 'io.ribot.app'
+    minSdkVersion 19
+    targetSdkVersion 23
+    testInstrumentationRunner "${applicationId}.runner.RxAndroidJUnitRunner"
+    versionCode 5000
+    // Major -> Millions, Minor -> Thousands, Bugfix -> Hundreds. E.g 1.3.72 == 1,003,072
+    versionName '0.5.0'
+    buildConfigField("String", "GOOGLE_API_SERVER_CLIENT_ID",
+    "\"${ribotAppGoogleApiServerClientId}\"")
     }
 
+    signingConfigs {
+    // You must set up an environment var before release signing
+    // Run: export RIBOT_APP_KEY={password}
+    release {
+    storeFile file("${ribotAppKeystoreReleaseLocation}")
+    keyAlias "${ribotAppReleaseKeyAlias}"
+    storePassword "${ribotAppReleaseStorePassword}"
+    keyPassword "${ribotAppReleaseKeyPassword}"
+    }
+
+    debug {
+    storeFile file("${ribotAppKeystoreDebugLocation}")
+    keyAlias "${ribotAppDebugKeyAlias}"
+    storePassword "${ribotAppDebugStorePassword}"
+    keyPassword "${ribotAppDebugKeyPassword}"
+    }
+    }
 
     buildTypes {
 
-        release {
+    release {
+    signingConfig signingConfigs.release
 
             /*
             * By default ProGuard optimizations are disabled. If you want to enable them
             * replace proguard-android.txt with proguard-android-optimize.txt but make sure you
             * test thoroughly if you go this route as app may become unstable.
             */
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
+    minifyEnabled true
+    proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+    }
 
-        debug {
-            versionNameSuffix " Debug"
-            debuggable true
-        }
+    debug {
+    versionNameSuffix " Debug"
+    debuggable true
+    }
     }
 
     sourceSets {
-        def commonTestDir = 'src/commonTest/java'
-        test {
-            java.srcDir commonTestDir
-        }
-        androidTest {
-            java.srcDir commonTestDir
-        }
+    def commonTestDir = 'src/commonTest/java'
+    test {
+    java.srcDir commonTestDir
+    }
+    androidTest {
+    java.srcDir commonTestDir
+    }
     }
 
     //Needed because of this https://github.com/square/okio/issues/58
     lintOptions {
-        warning 'InvalidPackage'
+    warning 'InvalidPackage'
     }
 
-}
+    }
 
-play {
+    play {
     track = 'alpha'
     serviceAccountEmail = "${ribotAppPlayStoreServiceAccount}"
     pk12File = file("${ribotAppPlayStorePk12Location}")
-}
+    }
 
-dependencies {
-    final PLAY_SERVICES_VERSION = '8.3.0'
-    final SUPPORT_LIBRARY_VERSION = '23.1.1'
-    final RETROFIT_VERSION = '2.0.0-beta3'
-    final DAGGER_VERSION = '2.0.2'
-    final DEXMAKER_VERSION = '1.4'
-    final HAMCREST_VERSION = '1.3'
-    final MOCKITO_VERSION = '1.10.19'
-    final ESPRESSO_VERSION = '2.2.1'
-    final UI_AUTOMATOR_VERSION = '2.1.2'
-    final JUNIT_VERSION = '4.12'
-    final RUNNER_VERSION = '0.4'
+    dependencies {
+final PLAY_SERVICES_VERSION = '8.3.0'
+final SUPPORT_LIBRARY_VERSION = '23.1.1'
+final RETROFIT_VERSION = '2.0.0-beta3'
+final OKHTTP_VERSION = '2.7.0'
+final DAGGER_VERSION = '2.0.2'
+final DEXMAKER_VERSION = '1.4'
+final HAMCREST_VERSION = '1.3'
+final MOCKITO_VERSION = '1.10.19'
+final ESPRESSO_VERSION = '2.2.1'
+final UI_AUTOMATOR_VERSION = '2.1.2'
+final JUNIT_VERSION = '4.12'
+final RUNNER_VERSION = '0.4'
 
     compile "com.google.android.gms:play-services-gcm:$PLAY_SERVICES_VERSION"
     compile "com.android.support:appcompat-v7:$SUPPORT_LIBRARY_VERSION"
@@ -106,9 +125,9 @@ dependencies {
     androidTestCompile "junit:junit:$JUNIT_VERSION"
     androidTestCompile "com.android.support:support-annotations:$SUPPORT_LIBRARY_VERSION"
     androidTestCompile("com.android.support.test.espresso:espresso-contrib:$ESPRESSO_VERSION") {
-        exclude group: 'com.android.support', module: 'appcompat'
-        exclude group: 'com.android.support', module: 'support-v4'
-        exclude group: 'com.android.support', module: 'recyclerview-v7'
+    exclude group: 'com.android.support', module: 'appcompat'
+    exclude group: 'com.android.support', module: 'support-v4'
+    exclude group: 'com.android.support', module: 'recyclerview-v7'
     }
     androidTestCompile "com.android.support.test.espresso:espresso-core:$ESPRESSO_VERSION"
     androidTestCompile "com.android.support.test.espresso:espresso-intents:$ESPRESSO_VERSION"
@@ -130,9 +149,9 @@ dependencies {
     testCompile 'org.robolectric:robolectric:3.0'
 
     testApt "com.google.dagger:dagger-compiler:$DAGGER_VERSION"
-}
+    }
 
-// Log out test results to console
-tasks.matching {it instanceof Test}.all {
+    // Log out test results to console
+    tasks.matching {it instanceof Test}.all {
     testLogging.events = ["failed", "passed", "skipped"]
-}
+    }

--- a/app/src/androidTest/java/io/ribot/app/SignInActivityTest.java
+++ b/app/src/androidTest/java/io/ribot/app/SignInActivityTest.java
@@ -25,8 +25,9 @@ import io.ribot.app.data.model.Ribot;
 import io.ribot.app.test.common.MockModelFabric;
 import io.ribot.app.test.common.TestComponentRule;
 import io.ribot.app.ui.signin.SignInActivity;
-import retrofit.HttpException;
-import retrofit.Response;
+
+import retrofit2.HttpException;
+import retrofit2.Response;
 import rx.Observable;
 import timber.log.Timber;
 

--- a/app/src/main/java/io/ribot/app/data/remote/UnauthorisedInterceptor.java
+++ b/app/src/main/java/io/ribot/app/data/remote/UnauthorisedInterceptor.java
@@ -3,37 +3,31 @@ package io.ribot.app.data.remote;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
-
-import com.squareup.okhttp.Interceptor;
-import com.squareup.okhttp.Response;
 import com.squareup.otto.Bus;
-
 import java.io.IOException;
-
 import javax.inject.Inject;
-
 import io.ribot.app.RibotApplication;
 import io.ribot.app.data.BusEvent;
+import okhttp3.Interceptor;
+import okhttp3.Response;
 
 public class UnauthorisedInterceptor implements Interceptor {
 
-    @Inject Bus eventBus;
+  @Inject Bus eventBus;
 
-    public UnauthorisedInterceptor(Context context) {
-        RibotApplication.get(context).getComponent().inject(this);
-    }
+  public UnauthorisedInterceptor(Context context) {
+    RibotApplication.get(context).getComponent().inject(this);
+  }
 
-    @Override
-    public Response intercept(Chain chain) throws IOException {
-        Response response = chain.proceed(chain.request());
-        if (response.code() == 401) {
-            new Handler(Looper.getMainLooper()).post(new Runnable() {
-                @Override
-                public void run() {
-                    eventBus.post(new BusEvent.AuthenticationError());
-                }
-            });
+  @Override public Response intercept(Chain chain) throws IOException {
+    Response response = chain.proceed(chain.request());
+    if (response.code() == 401) {
+      new Handler(Looper.getMainLooper()).post(new Runnable() {
+        @Override public void run() {
+          eventBus.post(new BusEvent.AuthenticationError());
         }
-        return response;
+      });
     }
+    return response;
+  }
 }

--- a/app/src/main/java/io/ribot/app/util/NetworkUtil.java
+++ b/app/src/main/java/io/ribot/app/util/NetworkUtil.java
@@ -3,8 +3,7 @@ package io.ribot.app.util;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-
-import retrofit.HttpException;
+import retrofit2.HttpException;
 
 public class NetworkUtil {
 


### PR DESCRIPTION
ah, now i see that looks messy because I didn't have my environment with the keys and didn't want to configure it. But you can do it manually if you want.

1. Modify your gradle file to

  compile 'com.squareup.retrofit2:retrofit:2.0.0-beta3'
  compile "com.squareup.retrofit2:converter-gson:2.0.0-beta3"
  compile "com.squareup.retrofit2:adapter-rxjava:2.0.0-beta3"
  compile 'com.squareup.okhttp3:logging-interceptor:3.0.1'


create a builder

      OkHttpClient.Builder builder = new OkHttpClient().newBuilder();
      builder.readTimeout(10, TimeUnit.SECONDS);
      builder.connectTimeout(5, TimeUnit.SECONDS);


and add interceptors to it.

this is all :)

